### PR TITLE
refactor: replace String and PathBuf with &str and &Path

### DIFF
--- a/src/file_layer/watcher.rs
+++ b/src/file_layer/watcher.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use notify::{Error, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{
@@ -14,7 +18,7 @@ use tokio::{
 };
 
 pub(crate) async fn create_watcher(
-    root: PathBuf,
+    root: &Path,
 ) -> Result<
     (
         Debouncer<RecommendedWatcher, RecommendedCache>,
@@ -91,8 +95,8 @@ pub async fn watch(
                                         let target_name = &e.event.paths[1];
                                         log::debug!(
                                             "[RENAME] {} -> {}",
-                                            strip_prefix(source_name, &root_path),
-                                            strip_prefix(target_name, &root_path)
+                                            strip_prefix(source_name, &root_path).display(),
+                                            strip_prefix(target_name, &root_path).display(),
                                         );
                                         files_changed = true;
                                     }
@@ -127,10 +131,6 @@ pub async fn watch(
     }
 }
 
-fn strip_prefix(path: &std::path::Path, prefix: &std::path::PathBuf) -> String {
-    path.strip_prefix(prefix)
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string()
+fn strip_prefix<'a>(path: &'a Path, prefix: &Path) -> &'a Path {
+    path.strip_prefix(prefix).unwrap()
 }

--- a/src/http_layer/listener.rs
+++ b/src/http_layer/listener.rs
@@ -3,7 +3,7 @@ use std::net::IpAddr;
 use local_ip_address::local_ip;
 use tokio::net::TcpListener;
 
-pub(crate) async fn create_listener(addr: String) -> Result<TcpListener, String> {
+pub(crate) async fn create_listener(addr: &str) -> Result<TcpListener, String> {
     match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => {
             let port = listener.local_addr().unwrap().port();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,12 @@ use http_layer::{
 use local_ip_address::local_ip;
 use notify::RecommendedWatcher;
 use notify_debouncer_full::{DebouncedEvent, Debouncer, RecommendedCache};
-use std::{error::Error, net::IpAddr, path::PathBuf, sync::Arc};
+use std::{
+    error::Error,
+    net::IpAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::{
     net::TcpListener,
     sync::{broadcast, mpsc::Receiver},
@@ -109,12 +114,9 @@ impl Listener {
 ///     listen("127.0.0.1:8080", "./").await?.start(Options::default()).await
 /// }
 /// ```
-pub async fn listen<A: Into<String>, R: Into<PathBuf>>(
-    addr: A,
-    root: R,
-) -> Result<Listener, String> {
-    let tcp_listener = create_listener(addr.into()).await?;
-    let (debouncer, root_path, rx) = create_watcher(root.into()).await?;
+pub async fn listen(addr: impl AsRef<str>, root: impl AsRef<Path>) -> Result<Listener, String> {
+    let tcp_listener = create_listener(addr.as_ref()).await?;
+    let (debouncer, root_path, rx) = create_watcher(root.as_ref()).await?;
 
     Ok(Listener {
         tcp_listener,


### PR DESCRIPTION
When ownership is not needed, prefer `&str` and `&Path` to `String` and `PathBuf`.