### PR TITLE
fix: browser extensiont conflict

### DIFF
--- a/src/templates/websocket.js
+++ b/src/templates/websocket.js
@@ -54,7 +54,7 @@
       // with the reload payload. If the reload payload
       // is absent, it probably means the server responded
       // with a 404 page
-      const meta = ifr.contentDocument.head.lastChild;
+      const meta = ifr.contentDocument.head.querySelector('meta[name="live-server"]')
       if (
         meta &&
         meta.tagName === "META" &&


### PR DESCRIPTION
Some browser extensions like Dark Reader may add custom meta tag to your page and this may has conflict with live-server.

This PR specify the meta tag by querying `meta[name="live-server"]`, in order to avoid the potential conflict caused by the extra custom tag created by browser extension.