### PR TITLE
Watch the root path literally instead of its source target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "open",
+ "path-absolutize",
  "reqwest",
  "tokio",
 ]
@@ -1204,6 +1205,24 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.31"
 mime_guess = "2.0.5"
 open = "5.3.2"
 ignore = "0.4.23"
+path-absolutize = "3.1.1"
 
 [dev-dependencies]
 reqwest = "0.12.4"

--- a/src/file_layer/watcher.rs
+++ b/src/file_layer/watcher.rs
@@ -56,7 +56,7 @@ pub async fn watch(
         match result {
             Ok(events) => {
                 for e in events {
-                    if  e.paths.iter().all(|p| !p.starts_with(&root_path)) {
+                    if e.paths.iter().all(|p| !p.starts_with(&root_path)) {
                         // All paths in this event are NOT related to the root path
                         log::debug!("Skipped files that are not in root: {:?}", e.paths);
                         continue;

--- a/src/file_layer/watcher.rs
+++ b/src/file_layer/watcher.rs
@@ -48,7 +48,7 @@ pub async fn watch(
 ) {
     let root_parent = root_path.parent();
     debouncer
-        .watch(&root_parent.unwrap_or(&root_path), RecursiveMode::Recursive)
+        .watch(root_parent.unwrap_or(&root_path), RecursiveMode::Recursive)
         .unwrap();
 
     while let Some(result) = rx.recv().await {

--- a/src/file_layer/watcher.rs
+++ b/src/file_layer/watcher.rs
@@ -58,7 +58,7 @@ pub async fn watch(
                 for e in events {
                     if  e.paths.iter().all(|p| !p.starts_with(&root_path)) {
                         // All paths in this event are NOT related to the root path
-                        log::trace!("Skipped files that are not in root: {:?}", e.paths);
+                        log::debug!("Skipped files that are not in root: {:?}", e.paths);
                         continue;
                     }
                     if ignore_files {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use http_layer::{
 use local_ip_address::local_ip;
 use notify::RecommendedWatcher;
 use notify_debouncer_full::{DebouncedEvent, Debouncer, RecommendedCache};
+use path_absolutize::Absolutize;
 use std::{
     error::Error,
     net::IpAddr,
@@ -35,7 +36,6 @@ use std::{
     sync::Arc,
 };
 use tokio::{
-    fs,
     net::TcpListener,
     sync::{broadcast, mpsc::Receiver},
 };
@@ -138,8 +138,8 @@ pub async fn listen(addr: impl AsRef<str>, root: impl AsRef<Path>) -> Result<Lis
 }
 
 async fn get_absolute_path(path: &Path) -> Result<PathBuf, String> {
-    match fs::canonicalize(path).await {
-        Ok(path) => Ok(path),
+    match path.absolutize() {
+        Ok(path) => Ok(path.to_path_buf()),
         Err(err) => {
             let err_msg = format!("Failed to get absolute path of {:?}: {}", path, err);
             log::error!("{err_msg}");


### PR DESCRIPTION
Solves #161.

## Main Changes

1. Watch the parent path of the root, and filter those changes which are not children of the root, or root itself.
2. Use `path-absolutize` to replace `fs::canonicalize`, in order to make sure link will not be parsed to target path.