### PR TITLE
Don't panic when something is already listening on the port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn run_listener<W: Watcher + Send + 'static>(listener: Listener<W>, args: 
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), String> {
     let env = Env::new().default_filter_or("info");
     env_logger::init_from_env(env);
 
@@ -81,10 +81,11 @@ async fn main() {
 
     let addr = format!("{host}:{port}");
     if args.poll {
-        let listener = listen_poll(addr, root).await.unwrap();
+        let listener = listen_poll(addr, root).await?;
         run_listener(listener, &args).await;
     } else {
-        let listener = listen(addr, root).await.unwrap();
+        let listener = listen(addr, root).await?;
         run_listener(listener, &args).await;
     };
+    Ok(())
 }


### PR DESCRIPTION
Before: 

```
$ live-server . --hard --open --port=8181
[2025-10-30T07:25:32Z ERROR live_server::http_layer::listener] Address 0.0.0.0:8181 is already in use

thread 'main' panicked at live-server-0.10.0/src/main.rs:55:45:
called `Result::unwrap()` on an `Err` value: "Address 0.0.0.0:8181 is already in use"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
$
```

After: 

```
$ cargo run --release -- --hard --open --port=8181
[2025-10-30T07:40:55Z ERROR live_server::http_layer::listener] Address 0.0.0.0:8181 is already in use
Error: "Address 0.0.0.0:8181 is already in use"
$
```